### PR TITLE
Change localization of "I'm feeling lucky"

### DIFF
--- a/website/public/locales/fr/tasks.json
+++ b/website/public/locales/fr/tasks.json
@@ -42,7 +42,7 @@
     "overview": "En fonction de la discussion suivante, fournir des étiquettes pour la dernière invitation."
   },
   "random": {
-    "label": "Je me sens chanceux",
+    "label": "J'ai de la chance",
     "desc": "Aidez-nous à améliorer Open Assistant en démarrant une tâche aléatoire."
   },
   "rank_assistant_replies": {


### PR DESCRIPTION
I'm assuming that message is meant to evoke Google's "I'm feeling lucky" option to skip search and directly get a result.

In the french version, this option is called "J'ai de la chance", so using that message would better convey the message and feel more familiar to french users.